### PR TITLE
Add write_rules to ranker

### DIFF
--- a/bindings.cpp
+++ b/bindings.cpp
@@ -27,6 +27,7 @@ PYBIND11_MODULE(c_clause, m) {
         .def(py::init<std::map<std::string, std::string>>(), py::arg("options"))
         .def("calculate_ranking", &RankingHandler::calculateRanking, py::arg("loader"))
         .def("write_ranking", &RankingHandler::writeRanking, py::arg("path"), py::arg("loader"))
+        .def("write_rules", &RankingHandler::writeRules, py::arg("path"), py::arg("loader"), py::arg("direction") = "tail", py::arg("as_string") = true)
         .def("set_options", &RankingHandler::setOptionsFrontend, py::arg("options"))
         .def(
             "get_ranking",

--- a/src/c_clause/api/RankingHandler.cpp
+++ b/src/c_clause/api/RankingHandler.cpp
@@ -58,6 +58,10 @@ void RankingHandler::writeRanking(std::string writePath, std::shared_ptr<Loader>
 
 }
 
+void RankingHandler::writeRules(std::string writePath, std::shared_ptr<Loader> dHandler, std::string direction, bool strings){
+    ranker.writeRules(dHandler->getTarget(), writePath, direction, strings);
+}
+
 
 std::unordered_map<int,std::unordered_map<int,std::vector<std::pair<int, double>>>> RankingHandler::getRanking(std::string headOrTail){
     if (headOrTail=="head"){

--- a/src/c_clause/api/RankingHandler.h
+++ b/src/c_clause/api/RankingHandler.h
@@ -22,6 +22,7 @@ public:
     void setCollectRules(bool ind);
     // exposed functions
     void writeRanking(std::string writePath, std::shared_ptr<Loader> dHandler);
+    void writeRules(std::string writePath, std::shared_ptr<Loader> dHandler, std::string direction, bool strings);
     void calculateRanking(std::shared_ptr<Loader> dHandler);
     std::unordered_map<int,std::unordered_map<int,std::vector<std::pair<int, double>>>> getRanking(std::string headOrTail);
     std::unordered_map<std::string, std::unordered_map<std::string, std::vector<std::pair<std::string, double>>>> getStrRanking(std::string headOrTail);

--- a/src/c_clause/features/Application.h
+++ b/src/c_clause/features/Application.h
@@ -32,6 +32,7 @@ public:
     // writes to e.g. this->headQueryResults[rel][head].aggrCand
     void makeRanking(TripleStorage& target, TripleStorage& train, RuleStorage& rules, TripleStorage& addFilter);
     void writeRanking(TripleStorage& target, std::string path);
+    void writeRules(TripleStorage& target, std::string path, std::string direction, bool strings);
 
     std::unordered_map<int,std::unordered_map<int, NodeToPredRules>>& getHeadQcandsRules();
     std::unordered_map<int,std::unordered_map<int, CandidateConfs>>&  getHeadQcandsConfs();


### PR DESCRIPTION
Added ability to write rules with the ranker,

e.g.

```python
ranker = RankingHandler(options.get("ranking_handler"))
ranker.calculate_ranking(loader)
ranker.write_rules(path, loader, direction="tail", as_string=True)
```